### PR TITLE
Example of adding reddit bin

### DIFF
--- a/bin/scrape_reddit
+++ b/bin/scrape_reddit
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+"""Simple commandline interface for scraping Reddit for live stream URLs."""
+import argparse
+import logging
+from streamscrape import reddit
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="""
+        Script to scrape Reddit for live stream URLS.
+        """
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        dest="verbose",
+        action="store_true",
+        help="Output INFO level logging.",
+    )
+    parser.add_argument(
+        "-vv",
+        "--veryverbose",
+        dest="debug",
+        action="store_true",
+        help="Output DEBUG level logging.",
+    )
+    args = parser.parse_args()
+
+    if args.debug:
+        log_level = logging.DEBUG
+    elif args.verbose:
+        log_level = logging.INFO
+    else:
+        log_level = logging.ERROR
+
+    # Configure logging for this application
+    log = logging.getLogger("[scraper]")
+    log.propagate = 0  # prevent propagation to the root logger
+    ch = logging.StreamHandler()
+    log.setLevel(log_level)
+    ch.setLevel(log_level)
+    formatter = logging.Formatter("[%(levelname)s] %(name)s - %(message)s")
+    ch.setFormatter(formatter)
+    log.addHandler(ch)
+
+    # Call the main routine
+    reddit.scrape()

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     py_modules=[splitext(basename(path))[0] for path in glob("src/*.py")],
     install_requires=["lxml", "beautifulsoup4", "requests", "praw"],
     keywords=["scraping", "streams"],
-    scripts=["bin/scrape_aggregators"],
+    scripts=["bin/scrape_aggregators", "bin/scrape_reddit"],
     url="https://github.com/hudson-ayers/safe-sports-streams",
     classifiers=[  # https://pypi.python.org/pypi?:action=list_classifiers
         "Development Status :: 3 - Alpha",

--- a/src/streamscrape/reddit/__init__.py
+++ b/src/streamscrape/reddit/__init__.py
@@ -1,0 +1,3 @@
+from streamscrape.reddit.core import scrape
+
+__all__ = ["scrape"]

--- a/src/streamscrape/reddit/core.py
+++ b/src/streamscrape/reddit/core.py
@@ -1,0 +1,2 @@
+def scrape():
+    print("Example.")


### PR DESCRIPTION
Here's an example of adding a bin and how it would be hooked up. The `__init__.py` of each python submodule defines what the public interface of the submodule is. So in this case I expose scrape from the core file in reddit. With an empty `__init__.py`, you'd have to do something like

```py
from streamscrape.reddit import core

core.scrape()
```

But because we expose scrape at the reddit submodule level, we can kind of hide that one layer.