### PR TITLE
Add basic LiveTV scraping

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,2 +1,8 @@
 [settings]
-known_third_party = praw,setuptools,streamscrape
+multi_line_output=3
+include_trailing_comma=True
+force_grid_wrap=0
+combine_as_imports=True
+line_length=88
+known_first_party = streamscrape, tests
+known_third_party = bs4,praw,requests,selenium,setuptools,streamscrape

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,6 @@ repos:
     - id: black
       language_version: python3
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v1.4.0
+    rev: v2.0.0
     hooks:
     - id: flake8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: python
 sudo: required
+addons:
+  apt:
+    packages:
+      - chromium-chromedriver
 dist: xenial
 python:
   - '3.6'
@@ -18,9 +22,10 @@ install:
 
 before_script:
   - make check
+  - ln -s /usr/lib/chromium-browser/chromedriver ~/bin/chromedriver
 
 script:
-  - coverage run --source=streamscrape -m pytest tests
+  - travis_wait coverage run --source=streamscrape -m pytest tests
 
 after_success:
   - coveralls

--- a/bin/scrape_aggregators
+++ b/bin/scrape_aggregators
@@ -2,6 +2,7 @@
 """Simple commandline interface for scraping aggregator sites for live stream URLs."""
 import argparse
 import logging
+from streamscrape import other
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
@@ -33,7 +34,7 @@ if __name__ == "__main__":
         log_level = logging.ERROR
 
     # Configure logging for this application
-    log = logging.getLogger("[scraper]")
+    log = logging.getLogger("streamscrape")
     log.propagate = 0  # prevent propagation to the root logger
     ch = logging.StreamHandler()
     log.setLevel(log_level)
@@ -43,3 +44,6 @@ if __name__ == "__main__":
     log.addHandler(ch)
 
     # Call the main routine
+    result = other.scrape()
+    for r in result:
+        print("[{}] {} ({})".format(r["timestamp"], r["url"], r["ip"]))

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     packages=find_packages("src"),
     package_dir={"": "src"},
     py_modules=[splitext(basename(path))[0] for path in glob("src/*.py")],
-    install_requires=["lxml", "beautifulsoup4", "requests", "praw"],
+    install_requires=["beautifulsoup4", "praw", "requests", "selenium"],
     keywords=["scraping", "streams"],
     scripts=["bin/scrape_aggregators", "bin/scrape_reddit"],
     url="https://github.com/hudson-ayers/safe-sports-streams",

--- a/src/streamscrape/other/__init__.py
+++ b/src/streamscrape/other/__init__.py
@@ -1,0 +1,3 @@
+from streamscrape.other.core import scrape
+
+__all__ = ["scrape"]

--- a/src/streamscrape/other/core.py
+++ b/src/streamscrape/other/core.py
@@ -13,7 +13,16 @@ Specifically, we look at:
     - https://www.batmanstream.net/
 """
 
+import logging
+
+from streamscrape.other import livetv
+
+logger = logging.getLogger(__name__)
+
 
 def scrape():
     """Core driver method for scraping other aggregator sites."""
-    return
+    total_urls = []
+    logger.info("Scraping http://livetv.sx")
+    total_urls.extend(livetv.scrape())
+    return total_urls

--- a/src/streamscrape/other/livetv.py
+++ b/src/streamscrape/other/livetv.py
@@ -1,0 +1,79 @@
+"""Code for scraping from LiveTV."""
+import logging
+import multiprocessing as mp
+from pprint import pformat
+
+import requests
+from bs4 import BeautifulSoup
+
+from streamscrape.utils import get_chrome_webdriver, get_ip_address, get_utc_time_str
+
+logger = logging.getLogger(__name__)
+
+LIVETV_HOME = "http://livetv.sx"
+
+
+def _scrape_event(url):
+    """Scrape a particular event URL.
+
+    :param url: The LiveTV Event URL to scrape for browser links.
+    :type url: string
+    :return: A tuple of dict {"timestamp": _, "url": _, "ip": _}
+    """
+    event_urls = set()
+    logger.debug("Scraping: {}".format(url))
+    driver = get_chrome_webdriver()
+    driver.get(url)
+    soup = BeautifulSoup(driver.page_source, "html.parser")
+    links_table = soup.find(id="links_block")
+
+    # remove header table, if present
+    try:
+        links_table.find(class_="lnkhdr").decompose()
+    except AttributeError:
+        # If no link table is present, just return an empty tuple
+        driver.quit()
+        return tuple()
+
+    for link in [a.attrs["href"] for a in links_table.find_all("a")]:
+        # Skip this URLs like ads/acestream
+        if any(s in link for s in ["#null", "unibet", "acestream", "sop"]):
+            continue
+
+        # Append http if it is missing. livetv does not use HTTPS.
+        if link.startswith("//"):
+            link = "http:" + link
+
+        event_data = (get_utc_time_str(), link, get_ip_address(link))
+        logger.debug("LiveTV URL data: {}".format(event_data))
+        event_urls.add(event_data)
+
+    driver.quit()
+    return tuple({"timestamp": e[0], "url": e[1], "ip": e[2]} for e in event_urls)
+
+
+def scrape():
+    """Scrape LiveTV.
+
+    :return: A list of {"timestamp": _, "url": _, "ip": _}
+    """
+    page = requests.get(LIVETV_HOME)
+    soup = BeautifulSoup(page.text, "html.parser")
+
+    # Gather current live URLs from the English ("enx") version of the page.
+    live_urls = set(
+        LIVETV_HOME + "/enx" + a.attrs["href"]
+        for a in soup.find_all("a", class_="live")
+    )
+
+    all_urls = []
+
+    # Process all urls in parallel.
+    with mp.Pool(2 * mp.cpu_count()) as p:
+        results = p.map(_scrape_event, live_urls)
+        for event_urls in results:
+            all_urls.extend(url for url in event_urls)
+
+    logger.debug("{}".format(pformat(all_urls)))
+
+    return all_urls

--- a/src/streamscrape/other/rojadirecta.py
+++ b/src/streamscrape/other/rojadirecta.py
@@ -1,0 +1,12 @@
+"""Code for scraping from RojaDirecta."""
+import logging
+
+logger = logging.getLogger(__name__)
+
+HOME = "http://www.rojadirecta.me"
+
+
+def scrape():
+    """Scrape RojaDirecta."""
+
+    return

--- a/src/streamscrape/reddit/core.py
+++ b/src/streamscrape/reddit/core.py
@@ -44,7 +44,7 @@ STREAMING_SUBREDDITS = [
 def find_urls(string):
     # findall() has been used
     # with valid conditions for urls in string
-    urls = re.findall("(?=\(http).+(?=\))", string)
+    urls = re.findall(r"(?=\(http).+(?=\))", string)
     # TODO: Make below code efficient instead of terrible (just change urls in place)
     urls_cleaned = []
     for url in urls:

--- a/src/streamscrape/utils/__init__.py
+++ b/src/streamscrape/utils/__init__.py
@@ -1,0 +1,8 @@
+from streamscrape.utils.utils import (
+    get_chrome_webdriver,
+    get_ip_address,
+    get_utc_time_str,
+)
+
+
+__all__ = ["get_utc_time_str", "get_ip_address", "get_chrome_webdriver"]

--- a/src/streamscrape/utils/utils.py
+++ b/src/streamscrape/utils/utils.py
@@ -1,0 +1,42 @@
+import socket
+from datetime import datetime
+from urllib.parse import urlparse
+
+from selenium import webdriver
+
+
+def get_utc_time_str():
+    """Return the current UTC time as a string.
+
+    :return: The current UTC time.
+    :rtype: str
+    """
+    return str(datetime.utcnow())
+
+
+def get_ip_address(url):
+    """Return the IPv4 address of the given URL.
+
+    :param url: The string URL to parse.
+    :return: The IPv4 address of the hostname.
+    :rtype: str
+    """
+    parsed_uri = urlparse(url)
+    return socket.gethostbyname(parsed_uri.netloc)
+
+
+def get_chrome_webdriver():
+    """Return a headless Chrome webdriver.
+
+    The caller is in charge of calling quit() on this driver so that there are
+    not chrome processes leftover after a run.
+    """
+    options = webdriver.ChromeOptions()
+    options.add_argument("headless")
+
+    # This window size is arbitrary. But, seems like it captures a good area
+    # if you wanted to screenshot the page.
+    options.add_argument("window-size=1200x800")
+    driver = webdriver.Chrome(options=options)
+
+    return driver

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -2,7 +2,7 @@
 addopts = -v -rsXx
 log_format = [%(levelname)s] %(message)s
 log_date_format = %Y-%m-%d %H:%M:%S
+log_cli = true
 
 ; The following options are useful for local debugging
-; addopts = -v -rsXx -s -x --pdb
-; log_cli = true
+; addopts = -v -rsXx -x --pdb

--- a/tests/test_livetv.py
+++ b/tests/test_livetv.py
@@ -1,0 +1,22 @@
+import logging
+from pprint import pformat
+
+from streamscrape.other import livetv
+
+
+def test_scrape_event(caplog):
+    """Just a passing test."""
+    caplog.set_level(logging.INFO)
+
+    livetv._scrape_event(
+        "http://livetv.sx/enx/eventinfo/720950_atp_challenger_traralgon/"
+    )
+
+
+def test_scrape(caplog):
+    """Just check that some urls are found."""
+    caplog.set_level(logging.INFO)
+    logger = logging.getLogger(__name__)
+    results = livetv.scrape()
+    logger.info("{}".format(pformat(results)))
+    assert len(results) > 0

--- a/tests/test_placeholder.py
+++ b/tests/test_placeholder.py
@@ -1,3 +1,0 @@
-def test_placeholder():
-    """Just a passing test."""
-    return


### PR DESCRIPTION
We use selenium to scrape LiveTV, and parallelize it to help compensate
for the overhead of launching headless Chrome. This also removes the
placeholder test.

The updates to the .isort.cfg just make it compatible with black's formatting.